### PR TITLE
Dynamic templates dev deliverer

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,28 @@ class TestMailer < ApplicationMailer
 end
 ```
 
+#### Set Dynamic Template Data
+
+```ruby
+class TestMailer < ApplicationMailer
+  def my_email
+    dynamic_template_data({ key1: "value1", key2: "value2" })
+    mail
+  end
+end
+```
+
+#### Add Category
+
+```ruby
+class TestMailer < ApplicationMailer
+  def my_email
+    add_category("value")
+    mail
+  end
+end
+```
+
 > Remember: you need to specify al least: `body`, `template_id` or a Rails template.
 
 ## Recipient Interceptor

--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -3,6 +3,7 @@ module SendGridMailer
     include InterceptorsHandler
     include Logger
     require "letter_opener"
+    require 'handlebars'
 
     def deliver!(sg_definition)
       @sg_definition = sg_definition
@@ -39,6 +40,8 @@ module SendGridMailer
       template_active_version = template_versions.find { |version| version["active"] == 1 }
       template_content = template_active_version["html_content"]
       @sg_definition.personalization.substitutions.each { |k, v| template_content.gsub!(k, v) }
+      template = Handlebars::Context.new.compile(template_content)
+      template_content = template.call(@sg_definition.personalization.dynamic_template_data)
       template_content
     end
 

--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -3,7 +3,7 @@ module SendGridMailer
     include InterceptorsHandler
     include Logger
     require "letter_opener"
-    require 'handlebars'
+    require "handlebars"
 
     def deliver!(sg_definition)
       @sg_definition = sg_definition
@@ -29,7 +29,9 @@ module SendGridMailer
     end
 
     def dev_emails_location
-      ENV['DEV_EMAILS_LOCATION'] || '/tmp/mails'
+      Rails.application.config.action_mailer.sendgrid_dev_settings[:emails_location] || "/tmp/mails"
+    rescue
+      "/tmp/mails"
     end
 
     def parsed_template

--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -24,7 +24,11 @@ module SendGridMailer
     end
 
     def letter_opener_delivery_method
-      @letter_opener_delivery_method ||= LetterOpener::DeliveryMethod.new(location: '/tmp/mails')
+      @letter_opener_delivery_method ||= LetterOpener::DeliveryMethod.new(location: dev_emails_location)
+    end
+
+    def dev_emails_location
+      ENV['DEV_EMAILS_LOCATION'] || '/tmp/mails'
     end
 
     def parsed_template

--- a/send_grid_mailer.gemspec
+++ b/send_grid_mailer.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 4.2.0"
   s.add_dependency "sendgrid-ruby", "~> 5", ">= 5.3.0"
   s.add_dependency "letter_opener", "~> 1.7.0"
+  s.add_dependency "handlebars", "~> 0.8.0"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-rails"
   s.add_development_dependency "sqlite3", "~> 1.4"

--- a/spec/dummy/app/mailers/test_mailer.rb
+++ b/spec/dummy/app/mailers/test_mailer.rb
@@ -84,4 +84,10 @@ class TestMailer < ApplicationMailer
     substitute "%key%", value
     mail(to: "r1@platan.us", body: "X")
   end
+
+  def dynamic_template_email(value)
+    set_template_id("XXX")
+    dynamic_template_data(key: value)
+    mail(to: "r1@platan.us")
+  end
 end


### PR DESCRIPTION
This PR adds the following changes:

- Add `handlebars` (templating engine used in dynamic templates) as a gem dependency, and use it to substitute dynamic template data when using the development environment deliverer.
- Add tests for the previously mentioned feature (git's diff detection got a little confused here, it's only one test and some rearrangements).
- Use Rails config to optionally read the location where `dev_deliverer`'s email files will be stored. This improves compatibility with other tools, such as Docker and [Letter Opener Web](https://github.com/fgrehm/letter_opener_web).
- Update the readme with some examples.